### PR TITLE
feat: migrate from Azure to k8s

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -1,4 +1,4 @@
-name: Build and deploy container
+name: Build and push container image
 
 on:
   push:
@@ -11,47 +11,39 @@ on:
       - main
 
 jobs:
-  build:
-    runs-on: "ubuntu-latest"
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - uses: actions/checkout@v6
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/crypto-price-notifier
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
-      - name: Log in to registry
-        uses: docker/login-action@v4
-        with:
-          registry: https://discordbotspricecheck.azurecr.io/
-          username: ${{ secrets.AZR_USERNAME }}
-          password: ${{ secrets.AZR_PASSWORD }}
-
-      - name: Build and push container image to registry
+      - name: Build and push
         uses: docker/build-push-action@v7
         with:
-          push: true
-          tags: discordbotspricecheck.azurecr.io/${{ secrets.AZR_USERNAME }}/price-notifier:${{ github.sha }}
-          file: ./Dockerfile
-
-  deploy:
-    needs: build
-    runs-on: "ubuntu-latest"
-    if: startsWith(github.ref, 'refs/tags/')
-    steps:
-      - uses: azure/login@v3
-        with:
-          creds: ${{ secrets.AZURE_CREDENTIALS }}
-
-      - name: "Deploy Price Notifier"
-        uses: azure/aci-deploy@v1
-        with:
-          resource-group: ${{ secrets.RESOURCE_GROUP }}
-          image: discordbotspricecheck.azurecr.io/${{ secrets.AZR_USERNAME }}/price-notifier:${{ github.sha }}
-          registry-login-server: discordbotspricecheck.azurecr.io
-          registry-username: ${{ secrets.AZR_USERNAME }}
-          registry-password: ${{ secrets.AZR_PASSWORD }}
-          name: price-notifier
-          location: "norway east"
-          dns-name-label: "price-notifier"
-          secure-environment-variables: |
-            BOT_CONFIGS=[{"token":"${{ secrets.DISCORD_TOKEN_ETH }}","crypto":"ETH","cryptoGecko":"ethereum"},{"token":"${{ secrets.DISCORD_TOKEN_BTC }}","crypto":"BTC","cryptoGecko":"bitcoin"}]
+          context: .
+          file: ./dockerfile
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ dist-ssr
 *.sw?
 .env
 settings.json
+
+# Real cluster secret (copied from k8s/secret.example.yaml) — never commit
+k8s/secret.yaml

--- a/k8s/README.md
+++ b/k8s/README.md
@@ -1,0 +1,90 @@
+# Kubernetes deployment
+
+Plain manifests applied by hand with `kubectl` — no ArgoCD/GitOps.
+
+The bot is a stateless Discord client: it opens an outbound WebSocket and
+listens on **no port**, so there is no Service, Ingress, or health probe.
+
+## Files
+
+| File                  | What it is                                             |
+| --------------------- | ------------------------------------------------------ |
+| `namespace.yaml`      | The `crypto-price-notifier` namespace.                 |
+| `deployment.yaml`     | The bot Deployment (1 replica).                        |
+| `secret.example.yaml` | Template for the Discord-token secret. **Copy, don't apply directly.** |
+
+The image is built and pushed to `ghcr.io/loekensgard/crypto-price-notifier`
+by `.github/workflows/build-and-push.yaml` on every push to `main`
+(tag `:main`) and on git tags (`:1.2.3`). The Deployment tracks `:main`.
+
+## First-time deploy
+
+Make sure you're pointed at the right cluster:
+
+```sh
+kubectl config current-context   # should be the target k8s cluster
+```
+
+### 1. Namespace
+
+```sh
+kubectl apply -f k8s/namespace.yaml
+```
+
+### 2. Image pull access
+
+The GHCR package is **private by default**, so the cluster can't pull it
+until you do one of:
+
+**Option A — make the package public (simplest).**
+GitHub → your profile → Packages → `crypto-price-notifier` → Package settings
+→ Change visibility → Public. Then delete the `imagePullSecrets` block in
+`deployment.yaml`.
+
+**Option B — create a pull secret.** Use a GitHub PAT with `read:packages`:
+
+```sh
+kubectl create secret docker-registry ghcr-pull \
+  --namespace crypto-price-notifier \
+  --docker-server=ghcr.io \
+  --docker-username=loekensgard \
+  --docker-password=<GITHUB_PAT_WITH_read:packages>
+```
+
+(`deployment.yaml` already references `imagePullSecrets: ghcr-pull`.)
+
+### 3. Discord tokens secret
+
+```sh
+cp k8s/secret.example.yaml k8s/secret.yaml
+# edit k8s/secret.yaml — paste the real ETH + BTC Discord tokens
+kubectl apply -f k8s/secret.yaml
+```
+
+`k8s/secret.yaml` is gitignored. Never commit real tokens.
+
+### 4. Deploy the bot
+
+```sh
+kubectl apply -f k8s/deployment.yaml
+```
+
+### 5. Verify
+
+```sh
+kubectl -n crypto-price-notifier get pods
+kubectl -n crypto-price-notifier logs -l app=crypto-price-notifier -f
+```
+
+## Updating
+
+After a new image is pushed to `:main`, roll the pod:
+
+```sh
+kubectl -n crypto-price-notifier rollout restart deployment/crypto-price-notifier
+```
+
+## Changing tokens
+
+Edit `k8s/secret.yaml`, re-apply, then `rollout restart` (env is read at
+startup).

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: crypto-price-notifier
+  namespace: crypto-price-notifier
+  labels:
+    app: crypto-price-notifier
+spec:
+  replicas: 1
+  # Bot holds no state; a single replica is correct. Running >1 would
+  # double every Discord nickname/presence update.
+  selector:
+    matchLabels:
+      app: crypto-price-notifier
+  template:
+    metadata:
+      labels:
+        app: crypto-price-notifier
+    spec:
+      # Pull secret for the (private by default) GHCR package.
+      # Remove this block if you make the package public instead.
+      imagePullSecrets:
+        - name: ghcr-pull
+      containers:
+        - name: crypto-price-notifier
+          image: ghcr.io/loekensgard/crypto-price-notifier:main
+          # :main is overwritten on every push to main, so always re-pull.
+          imagePullPolicy: Always
+          env:
+            - name: BOT_CONFIGS
+              valueFrom:
+                secretKeyRef:
+                  name: crypto-price-notifier-secrets
+                  key: BOT_CONFIGS
+          resources:
+            requests:
+              cpu: "50m"
+              memory: "64Mi"
+            limits:
+              memory: "128Mi"
+      # No Service/Ingress and no probes: the bot opens an outbound
+      # Discord WebSocket and listens on no port.

--- a/k8s/namespace.yaml
+++ b/k8s/namespace.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: crypto-price-notifier
+  labels:
+    app: crypto-price-notifier

--- a/k8s/secret.example.yaml
+++ b/k8s/secret.example.yaml
@@ -1,0 +1,16 @@
+# Template only. Copy to k8s/secret.yaml, fill in the real Discord tokens,
+# and apply it. k8s/secret.yaml is gitignored — NEVER commit real tokens.
+#
+#   cp k8s/secret.example.yaml k8s/secret.yaml
+#   # edit k8s/secret.yaml, then:
+#   kubectl apply -f k8s/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: crypto-price-notifier-secrets
+  namespace: crypto-price-notifier
+type: Opaque
+stringData:
+  # Single JSON array string, exactly as the app's BOT_CONFIGS env expects.
+  BOT_CONFIGS: |
+    [{"token":"REPLACE_ETH_DISCORD_TOKEN","crypto":"ETH","cryptoGecko":"ethereum"},{"token":"REPLACE_BTC_DISCORD_TOKEN","crypto":"BTC","cryptoGecko":"bitcoin"}]


### PR DESCRIPTION
## What

Migrate the crypto price Discord bot off Azure (ACR + Container Instances) to a k8s cluster, deployed by hand with `kubectl`.

## Changes

- **Workflow** (`.github/workflows/build-and-push.yaml`): replace the Azure ACR build + ACI deploy with a self-contained job that builds and pushes to `ghcr.io/loekensgard/crypto-price-notifier`. Builds on push to `main` (`:main`), PRs (no push), and tags (semver). Fixed `file: ./dockerfile` (lowercase — Linux runners are case-sensitive).
- **k8s manifests** (`k8s/`): `namespace.yaml`, `deployment.yaml` (1 replica, `BOT_CONFIGS` from a Secret, no Service/Ingress/probe — the bot listens on no port), and `secret.example.yaml` template. `k8s/README.md` documents the deploy steps.
- `.gitignore`: ignore `k8s/secret.yaml` (real tokens never committed).

## Manual steps after merge

1. Make the GHCR package public **or** create a `ghcr-pull` secret (README step 2).
2. `cp k8s/secret.example.yaml k8s/secret.yaml`, paste real Discord tokens, apply.
3. `kubectl apply` namespace → secret → deployment.
4. Decommission the old Azure ACI and delete unused GitHub secrets (`AZR_*`, `AZURE_CREDENTIALS`, `RESOURCE_GROUP`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)